### PR TITLE
fix hex alphabet from 0-9A-G to 0-9A-F (#4)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ wchar_t HexLetter(int x) {
   if (x <= 9)
     return U'0' + x;
   else
-    return U'A' + x - 9;
+    return U'A' + x - 0xA;
 };
 
 std::wstring HexColor(int r, int g, int b) {


### PR DESCRIPTION
Fixes the off-by-one bug in `HexLetter` described in #4. 

Using hex notation `0xA` instead of `10` for symmetry with the wide char literal `U'A'`.